### PR TITLE
Add omero-web-zarr check

### DIFF
--- a/omero_vitessce/templates/omero_vitessce/vitessce_panel.html
+++ b/omero_vitessce/templates/omero_vitessce/vitessce_panel.html
@@ -13,18 +13,25 @@
 					<li><h1><a href={{url}} target="_blank"> {{file}}</a></h1></li>
 				{% endfor %}
 				 </ul> 
-				<p> Or use the form below to autogenerate one:</p>
 			{% else %}
 				<p> There are no config files attached! </p>
-				<p> Either attach a config file or use the form below to autogenerate one:</p>
+				<p> To use the viewer you can attach a .json config file and refresh the panel. </p>
 			{% endif %}
-			<form action='/omero_vitessce/generate_config/{{obj_type}}/{{obj_id}}' method="post">
-				{% csrf_token %}
-				<table>
-				{{ form.as_table }}
-				</table>
-				<input type = "submit" value = "Generate Config"> 
-			</form>
+				<br>
+			{% if form %}
+				 <p> Or use the form below to generate a new config file:</p>
+				<form action='/omero_vitessce/generate_config/{{obj_type}}/{{obj_id}}' method="post">
+					{% csrf_token %}
+					<table>
+					{{ form.as_table }}
+					</table>
+					<input type = "submit" value = "Generate Config"> 
+				</form>
+			{% else %}
+				<p> Autogenerating config files requires the 
+				<a  href=https://github.com/ome/omero-web-zarr target="_blank">omero-web-zarr</a>
+				plugin which seems not to be available. </p>
+			{% endif %}
 			</div>
 		</body>
 </html>

--- a/omero_vitessce/utils.py
+++ b/omero_vitessce/utils.py
@@ -17,7 +17,7 @@ def get_files_images(obj_type, obj_id, conn):
     """ Gets all the non config files attached to an object,
     and images if the object is a dataset,
     and returns a list of file names and a list of urls
-    for the files and eventually the images
+    for the files and eventually the images.
     """
     obj = conn.getObject(obj_type, obj_id)
     file_names = [

--- a/omero_vitessce/views.py
+++ b/omero_vitessce/views.py
@@ -7,6 +7,13 @@ from .forms import ConfigForm
 from .utils import get_attached_configs, create_config, attach_config
 from .utils import get_files_images, build_viewer_url
 
+from omeroweb.settings import ADDITIONAL_APPS
+
+# Check if omero_web_zarr is installed and configured
+# If "omero_web_zarr" is included in ADDITIONAL_APPS but
+# not installed omero web would not start, so no need to check
+OMERO_WEB_ZARR = "omero_web_zarr" in ADDITIONAL_APPS
+
 
 @login_required()
 def vitessce_index(request, conn=None, **kwargs):
@@ -28,10 +35,13 @@ def vitessce_panel(request, obj_type, obj_id, conn=None, **kwargs):
     context = {"json_configs": dict(zip(config_files, config_urls)),
                "obj_type": obj_type, "obj_id": obj_id}
 
-    files, urls, img_files, img_urls = get_files_images(
-            obj_type, obj_id, conn)
-    form = ConfigForm(files, urls, img_files, img_urls)
-    context["form"] = form
+    if OMERO_WEB_ZARR:
+        files, urls, img_files, img_urls = get_files_images(
+                obj_type, obj_id, conn)
+        form = ConfigForm(files, urls, img_files, img_urls)
+        context["form"] = form
+    else:
+        context["form"] = None
 
     return render(request, "omero_vitessce/vitessce_panel.html", context)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="omero-vitessce",
-    version="1.0.1",
+    version="1.0.2",
     description="OMERO Vitessce multimodal data viewer plugin for OMERO.web",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Adds a check to see if omero-web-zarr is configured. If not, then the form for generating a config file is not shown.